### PR TITLE
fix(file): updated reader to correctly read chuncks to EOF

### DIFF
--- a/s3file.go
+++ b/s3file.go
@@ -84,7 +84,9 @@ func (s3f *s3File) ReadAt(p []byte, offset int64) (n int, err error) {
 		return 0, err
 	}
 
-	size, err := r.Read(p)
+	// ensure the buffer is read, or EOF is reached for this read of this "chunk"
+	// given we are using offsets to read this block it is constrained by size of `p`
+	size, err := io.ReadFull(r, p)
 	if err != nil {
 		if err != io.EOF {
 			return size, err


### PR DESCRIPTION
Due to the nature of HTTP connections a single read won't work, we need to drain the entire stream to get what we requested using offsets from S3.
