### PR TITLE
feat(remove): added support for removing files via an extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package provides an S3 implementation for [Go1.16 filesystem interface](htt
 
 This package provides an S3 implementation for the Go1.16 filesystem interface using the [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2).
 
-The `S3FS` is currently read-only, and implements the following interfaces:
+The `S3FS` implements the following interfaces:
 
 - `fs.FS`
 - `fs.StatFS`
@@ -18,6 +18,10 @@ The `s3File` implements the following interfaces:
 - `fs.DirEntry`
 - `io.ReaderAt`
 - `io.Seeker`
+
+In addition to this the `S3FS` also implements the following interfaces:
+
+- `RemoveFS`, which provides a `Remove(name string) error` method.
 
 This enables libraries such as [apache arrow](https://arrow.apache.org/) to read parts of a parquet file from S3, without downloading the entire file.
 # Usage 

--- a/integration/s3fs_test.go
+++ b/integration/s3fs_test.go
@@ -237,3 +237,19 @@ func TestReadBigEOF(t *testing.T) {
 	assert.ErrorIs(err, io.ErrUnexpectedEOF)
 	assert.Equal(oneMegabyte, n)
 }
+
+func TestRemove(t *testing.T) {
+	assert := require.New(t)
+
+	_, err := client.PutObject(context.Background(), &s3.PutObjectInput{
+		Bucket: aws.String(testBucketName),
+		Key:    aws.String("test_remove.txt"),
+		Body:   bytes.NewReader(generateData(oneMegabyte)),
+	})
+	assert.NoError(err)
+
+	s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+	err = s3fs.Remove("test_remove.txt")
+	assert.NoError(err)
+}

--- a/integration/s3fs_test.go
+++ b/integration/s3fs_test.go
@@ -94,6 +94,8 @@ func TestSeek(t *testing.T) {
 	s3fs := s3iofs.NewWithClient(testBucketName, client)
 
 	t.Run("seek to start", func(t *testing.T) {
+		assert := require.New(t)
+
 		f, err := s3fs.Open("test_seek.txt")
 		assert.NoError(err)
 
@@ -112,6 +114,8 @@ func TestSeek(t *testing.T) {
 	})
 
 	t.Run("seek to end", func(t *testing.T) {
+		assert := require.New(t)
+
 		f, err := s3fs.Open("test_seek.txt")
 		assert.NoError(err)
 		defer f.Close()
@@ -124,6 +128,8 @@ func TestSeek(t *testing.T) {
 	})
 
 	t.Run("seek to current", func(t *testing.T) {
+		assert := require.New(t)
+
 		f, err := s3fs.Open("test_seek.txt")
 		assert.NoError(err)
 		defer f.Close()
@@ -239,17 +245,47 @@ func TestReadBigEOF(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	assert := require.New(t)
 
-	_, err := client.PutObject(context.Background(), &s3.PutObjectInput{
-		Bucket: aws.String(testBucketName),
-		Key:    aws.String("test_remove.txt"),
-		Body:   bytes.NewReader(generateData(oneMegabyte)),
+	t.Run("create and remove", func(t *testing.T) {
+		assert := require.New(t)
+
+		_, err := client.PutObject(context.Background(), &s3.PutObjectInput{
+			Bucket: aws.String(testBucketName),
+			Key:    aws.String("test_remove.txt"),
+			Body:   bytes.NewReader(generateData(oneMegabyte)),
+		})
+		assert.NoError(err)
+
+		s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+		err = s3fs.Remove("test_remove.txt")
+		assert.NoError(err)
 	})
-	assert.NoError(err)
 
-	s3fs := s3iofs.NewWithClient(testBucketName, client)
+	t.Run("removing non existent file should not error", func(t *testing.T) {
+		assert := require.New(t)
 
-	err = s3fs.Remove("test_remove.txt")
-	assert.NoError(err)
+		s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+		err := s3fs.Remove("test_remove_not_exists.txt")
+		assert.NoError(err)
+	})
+
+	t.Run("bad bucket name should error", func(t *testing.T) {
+		assert := require.New(t)
+
+		s3fs := s3iofs.NewWithClient("badbucket", client)
+
+		err := s3fs.Remove("test_remove_not_exists.txt")
+		assert.Error(err)
+	})
+
+	t.Run("invalid name should error", func(t *testing.T) {
+		assert := require.New(t)
+
+		s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+		err := s3fs.Remove("")
+		assert.Error(err)
+	})
 }

--- a/s3.go
+++ b/s3.go
@@ -11,4 +11,5 @@ type S3API interface {
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
 	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
 }

--- a/s3file_test.go
+++ b/s3file_test.go
@@ -37,6 +37,11 @@ func (m *mockS3Client) ListObjectsV2(ctx context.Context, params *s3.ListObjects
 	return args.Get(0).(*s3.ListObjectsV2Output), args.Error(1)
 }
 
+func (m *mockS3Client) DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*s3.DeleteObjectOutput), args.Error(1)
+}
+
 func TestReadFile(t *testing.T) {
 	type args struct {
 		bucket string

--- a/s3iofs.go
+++ b/s3iofs.go
@@ -175,12 +175,6 @@ func (s3fs *S3FS) Remove(name string) error {
 		Key:    aws.String(name),
 	})
 	if err != nil {
-		var nfe *types.NotFound
-		if errors.As(err, &nfe) {
-			// deleting a file which doesn't exist is not an error
-			return nil
-		}
-
 		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
 


### PR DESCRIPTION
To enable removal of files, and support the work going on in https://github.com/apache/iceberg-go I have added a new extension to s3iofs which supports the remove file operation.

This is inline with the recommendations in this issue discussing adding write support to `io.FS` and how implementations should provide their own extensions for this at the moment. https://github.com/golang/go/issues/45757