### PR TITLE
feat(write_file): added write file extension for simple put object

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `s3File` implements the following interfaces:
 In addition to this the `S3FS` also implements the following interfaces:
 
 - `RemoveFS`, which provides a `Remove(name string) error` method.
+- `WriteFileFS` which provides a `WriteFile(name string, data []byte, perm fs.FileMode) error` method.
 
 This enables libraries such as [apache arrow](https://arrow.apache.org/) to read parts of a parquet file from S3, without downloading the entire file.
 # Usage 

--- a/integration/s3fs_test.go
+++ b/integration/s3fs_test.go
@@ -289,3 +289,28 @@ func TestRemove(t *testing.T) {
 		assert.Error(err)
 	})
 }
+
+func TestWriteFile(t *testing.T) {
+
+	t.Run("should write and read file", func(t *testing.T) {
+		assert := require.New(t)
+
+		s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+		err := s3fs.WriteFile("test_write_read.txt", oneKilobyte, 0644)
+		assert.NoError(err)
+
+		data, err := fs.ReadFile(s3fs, "test_write_read.txt")
+		assert.NoError(err)
+		assert.Equal(oneKilobyte, data)
+	})
+
+	t.Run("invalid name should error", func(t *testing.T) {
+		assert := require.New(t)
+
+		s3fs := s3iofs.NewWithClient(testBucketName, client)
+
+		err := s3fs.WriteFile("", []byte{}, 0644)
+		assert.Error(err)
+	})
+}

--- a/s3.go
+++ b/s3.go
@@ -12,4 +12,5 @@ type S3API interface {
 	ListObjectsV2(ctx context.Context, params *s3.ListObjectsV2Input, optFns ...func(*s3.Options)) (*s3.ListObjectsV2Output, error)
 	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 }

--- a/s3file_test.go
+++ b/s3file_test.go
@@ -42,6 +42,11 @@ func (m *mockS3Client) DeleteObject(ctx context.Context, params *s3.DeleteObject
 	return args.Get(0).(*s3.DeleteObjectOutput), args.Error(1)
 }
 
+func (m *mockS3Client) PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	args := m.Called(ctx, params, optFns)
+	return args.Get(0).(*s3.PutObjectOutput), args.Error(1)
+}
+
 func TestReadFile(t *testing.T) {
 	type args struct {
 		bucket string


### PR DESCRIPTION
This adds a `WriteFileFS` extension to enable simple uploads of files without adding complex streaming or multi part uploads.
