### PR TITLE
feat(dirfs): added support for fs.ReadDirFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The `s3File` implements the following interfaces:
 
 - `fs.FileInfo`
 - `fs.DirEntry`
+- `fs.ReadDirFile`
 - `io.ReaderAt`
 - `io.Seeker`
 
@@ -24,7 +25,8 @@ In addition to this the `S3FS` also implements the following interfaces:
 - `RemoveFS`, which provides a `Remove(name string) error` method.
 - `WriteFileFS` which provides a `WriteFile(name string, data []byte, perm fs.FileMode) error` method.
 
-This enables libraries such as [apache arrow](https://arrow.apache.org/) to read parts of a parquet file from S3, without downloading the entire file.
+The `Seek` and `ReadAt` operations enable libraries such as [apache arrow](https://arrow.apache.org/) to read parts of a parquet file from S3, without downloading the entire file.
+
 # Usage 
 
 ```go

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -69,11 +69,12 @@ func TestMain(m *testing.M) {
 		var logmode aws.ClientLogMode
 
 		if os.Getenv("AWS_DEBUG") != "" {
-			logmode = aws.LogRetries | aws.LogRequest
+			logmode = aws.LogRetries | aws.LogRequest | aws.LogResponse
 		}
 
 		client = s3.New(s3.Options{
 			ClientLogMode:      logmode,
+			UsePathStyle:       true,
 			Logger:             logging.NewStandardLogger(os.Stdout),
 			EndpointResolverV2: &Resolver{URL: endpointURL},
 			Credentials: aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {


### PR DESCRIPTION
The `fs.ReadDirFS` extension was added to the go fs package after I wrote this package, however it provides a valueble tool when iterating over sub folders, and provides a handy paging method.
