### PR TITLE
fix(s3fs): fix directory and file detection logic in stat function

### DIFF
--- a/s3iofs.go
+++ b/s3iofs.go
@@ -186,7 +186,6 @@ func (s3fs *S3FS) WriteFile(name string, data []byte, perm os.FileMode) error {
 		Key:    aws.String(name),
 		Body:   bytes.NewReader(data),
 	})
-
 	if err != nil {
 		return &fs.PathError{Op: "write", Path: name, Err: err}
 	}
@@ -207,30 +206,30 @@ func (s3fs *S3FS) stat(name string) (fs.FileInfo, error) {
 		Bucket:    aws.String(s3fs.bucket),
 		Prefix:    aws.String(name),
 		Delimiter: aws.String("/"),
-		MaxKeys:   aws.Int32(1),
 	})
 	if err != nil {
 		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
 	}
 
-	if len(list.CommonPrefixes) > 0 &&
-		aws.ToString(list.CommonPrefixes[0].Prefix) == name+"/" {
-
-		return &s3File{
-			name:   name,
-			bucket: s3fs.bucket,
-			mode:   fs.ModeDir,
-		}, nil
+	for _, commonPrefix := range list.CommonPrefixes {
+		if aws.ToString(commonPrefix.Prefix) == name+"/" {
+			return &s3File{
+				name:   name,
+				bucket: s3fs.bucket,
+				mode:   fs.ModeDir,
+			}, nil
+		}
 	}
 
-	if len(list.Contents) > 0 &&
-		aws.ToString(list.Contents[0].Key) == name {
-		return &s3File{
-			name:    name,
-			bucket:  s3fs.bucket,
-			size:    aws.ToInt64(list.Contents[0].Size),
-			modTime: aws.ToTime(list.Contents[0].LastModified),
-		}, nil
+	for _, content := range list.Contents {
+		if aws.ToString(content.Key) == name {
+			return &s3File{
+				name:    name,
+				bucket:  s3fs.bucket,
+				size:    aws.ToInt64(content.Size),
+				modTime: aws.ToTime(content.LastModified),
+			}, nil
+		}
 	}
 
 	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}


### PR DESCRIPTION
- Remove MaxKeys limit to allow proper detection of multiple S3 objects
- Refactor directory detection to loop through all CommonPrefixes
- Refactor file detection to loop through all Contents
- Fix file size and modification time reference bug (use content instead of list.Contents[0])
- Remove extra blank line in WriteFile function

Changes explained:
- With MaxKeys=1 removed, stat function can correctly detect directories and files
- Previous implementation assumed the first element in the list was the target file/directory, which could fail when multiple objects share the same prefix
- Now properly loops through all possible matches